### PR TITLE
Push image to GitHub Container Registry too

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   Test:
-      runs-on: ubuntu-latest
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2
@@ -40,18 +40,18 @@ jobs:
        - name: Push to GitHub Container Eegistry
          run: |
           IMAGE_ID=ghcr.io/${{ github.repository_owner }}/samproxy-fargate-image
-          
+
           # Change all uppercase to lowercase
           IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
-          
+
           # Strip git ref prefix from version
           VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
-          
+
           # Use Docker `latest` tag convention
           [ "$VERSION" == "$default-branch" ] && VERSION=latest
-          
+
           echo IMAGE_ID=$IMAGE_ID
           echo VERSION=$VERSION
-          
+
           docker tag samproxy-fargate-image $IMAGE_ID:$VERSION
           docker push $IMAGE_ID:$VERSION

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,7 +18,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
 
       - name: Test the build
         run: docker build .
@@ -26,6 +27,7 @@ jobs:
   GitHub:
     name: GitHub Package Registry
     runs-on: ubuntu-latest
+    
     needs: test
     if: github.event_name == 'push'
 
@@ -37,8 +39,8 @@ jobs:
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
 
-       - name: Push to GitHub Container Eegistry
-         run: |
+      - name: Push the image to GitHub Container Eegistry
+        run: |
           IMAGE_ID=ghcr.io/${{ github.repository_owner }}/samproxy-fargate-image
 
           # Change all uppercase to lowercase

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,57 @@
+name: Docker
+
+on:
+  push:
+    # Publish `$default-branch` as Docker `latest` image.
+    branches:
+      - $default-branch
+
+    # Publish `v1.2.3` tags as releases.
+    tags:
+      - v*
+
+  # Run tests for any PRs.
+  pull_request:
+
+jobs:
+  Test:
+      runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Test the build
+        run: docker build .
+
+  GitHub:
+    name: GitHub Package Registry
+    runs-on: ubuntu-latest
+    needs: test
+    if: github.event_name == 'push'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Login to GitHub Container Registry
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
+
+       - name: Push to GitHub Container Eegistry
+         run: |
+          IMAGE_ID=ghcr.io/${{ github.repository_owner }}/samproxy-fargate-image
+          
+          # Change all uppercase to lowercase
+          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+          
+          # Strip git ref prefix from version
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+          
+          # Use Docker `latest` tag convention
+          [ "$VERSION" == "$default-branch" ] && VERSION=latest
+          
+          echo IMAGE_ID=$IMAGE_ID
+          echo VERSION=$VERSION
+          
+          docker tag samproxy-fargate-image $IMAGE_ID:$VERSION
+          docker push $IMAGE_ID:$VERSION


### PR DESCRIPTION
GitHub Package Registry [had no anonymous public pulls](https://github.com/containerd/containerd/issues/3291#issuecomment-685022382), which meant it was pretty useless for open-source. Today, [GitHub announced thee GitHub Container Registry](https://github.blog/2020-09-01-introducing-github-container-registry/) which fixes that 🎉 

This PR adds a GitHub Action for pushing to the new GitHub Container Registry.